### PR TITLE
Issue/4 Hide some facets from the user at first load

### DIFF
--- a/ckanext/digitizationknowledge/plugin.py
+++ b/ckanext/digitizationknowledge/plugin.py
@@ -127,26 +127,29 @@ class DigitizationknowledgePlugin(plugins.SingletonPlugin):
         """Modify the facets_dict and return it
         """
         new_facets = OrderedDict()
-        new_facets['type'] = toolkit._('Digitization Resource Type')
-        new_facets['category'] = toolkit._('Categories')
-        new_facets['in_digitization_academy_course'] = toolkit._('In Digitization Academy Course')
-        new_facets['digitization_academy_course'] = toolkit._('Digitization Academy Course')
+        # Basic facets
         new_facets['task_clusters'] = toolkit._('Task Clusters')
         new_facets['task'] = toolkit._('Tasks')
         new_facets['preparations'] = toolkit._('Preparations')
-        new_facets['audience'] = toolkit._('Audience')
+        new_facets['tags'] = toolkit._('Tags')
+        new_facets['digitization_academy_course'] = toolkit._('Digitization Academy Course')
         new_facets['discipline'] = toolkit._('Discipline')
-        new_facets['equipment'] = toolkit._('Equipment')
+        new_facets['audience'] = toolkit._('Audience')
         new_facets['in_language']= toolkit._('Language')
-
         
+        # Advanced facets
+        new_facets['category'] = toolkit._('Categories')
+        new_facets['organization'] = toolkit._('Organizations')
+ 
+        new_facets['groups'] = toolkit._('Groups')
+        new_facets['in_digitization_academy_course'] = toolkit._('In Digitization Academy Course')
+        new_facets['type'] = toolkit._('Resource Type')
+                
 
-        facets_to_exclude = {'res_format', 'license_id'}
+        # Return only the facets defined above, ignoring CKAN's default
+        # facets entirely so the search interface shows exactly the
+        # desired set in the specified order.
 
-        # Add the rest of the facets
-        for key, value in facets_dict.items():
-            if key not in facets_to_exclude:
-                new_facets[key] = value
 
         return new_facets
     

--- a/ckanext/digitizationknowledge/plugin.py
+++ b/ckanext/digitizationknowledge/plugin.py
@@ -122,7 +122,7 @@ class DigitizationknowledgePlugin(plugins.SingletonPlugin):
         return validators.get_validators()
     
     # IFacets
-
+    # TODO make the facets dynamic thatcan be loaded from the ckan.ini config file without needing to change source code for the plugin.
     def dataset_facets(self, facets_dict, package_type):
         """Modify the facets_dict and return it
         """
@@ -132,18 +132,18 @@ class DigitizationknowledgePlugin(plugins.SingletonPlugin):
         new_facets['task'] = toolkit._('Tasks')
         new_facets['preparations'] = toolkit._('Preparations')
         new_facets['tags'] = toolkit._('Tags')
-        new_facets['digitization_academy_course'] = toolkit._('Digitization Academy Course')
+        new_facets['digitization_academy_course'] = toolkit._('Digitization Academy Courses')
         new_facets['discipline'] = toolkit._('Discipline')
         new_facets['audience'] = toolkit._('Audience')
-        new_facets['in_language']= toolkit._('Language')
+        new_facets['in_language']= toolkit._('Languages')
         
         # Advanced facets
         new_facets['category'] = toolkit._('Categories')
         new_facets['organization'] = toolkit._('Organizations')
  
         new_facets['groups'] = toolkit._('Groups')
-        new_facets['in_digitization_academy_course'] = toolkit._('In Digitization Academy Course')
-        new_facets['type'] = toolkit._('Resource Type')
+        new_facets['in_digitization_academy_course'] = toolkit._('In Digitization Academy Courses')
+        new_facets['type'] = toolkit._('Resource Types')
                 
 
         # Return only the facets defined above, ignoring CKAN's default

--- a/ckanext/digitizationknowledge/templates/base.html
+++ b/ckanext/digitizationknowledge/templates/base.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block styles %}
+  {{ super() }}
+  {% asset 'digitizationknowledge_theme/main-css' %}
+  <script src="//unpkg.com/alpinejs" defer></script>
+{% endblock %}

--- a/ckanext/digitizationknowledge/templates/package/search.html
+++ b/ckanext/digitizationknowledge/templates/package/search.html
@@ -75,7 +75,7 @@
 {% block secondary_content %}
 
 
-{% set basic_facets = ['type', 'category', 'tags'] %}
+{% set basic_facets = ['task_clusters', 'task', 'preparations', 'tags', 'digitization_academy_course', 'discipline', 'audience', 'in_language', ] %}
 {% set all_facet_keys = facet_titles.keys() | list %}
 {% set advanced_facets = all_facet_keys | reject('in', basic_facets) | list %}
 

--- a/ckanext/digitizationknowledge/templates/package/search.html
+++ b/ckanext/digitizationknowledge/templates/package/search.html
@@ -71,3 +71,58 @@
 </div>
 {% endif %}
 {%endblock%}
+
+{% block secondary_content %}
+
+
+{% set basic_facets = ['type', 'category', 'tags'] %}
+{% set all_facet_keys = facet_titles.keys() | list %}
+{% set advanced_facets = all_facet_keys | reject('in', basic_facets) | list %}
+
+  <div class="filters" x-data="{showAdvanced:false}" x-cloak>
+    <div>
+      <!-- Basic facets - always shown -->
+      {% for facet in basic_facets %}
+        {% if facet in facet_titles %}
+          {% snippet 'snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets %}
+        {% endif %}
+      {% endfor %}
+
+          <!-- Advanced facets - conditionally shown -->
+    {% if advanced_facets %}
+      <div x-show="showAdvanced" 
+           x-cloak
+           x-transition:enter="transition ease-out duration-300"
+           x-transition:enter-start="opacity-0 transform -translate-y-2"
+           x-transition:enter-end="opacity-100 transform translate-y-0"
+           x-transition:leave="transition ease-in duration-200"
+           x-transition:leave-start="opacity-100 transform translate-y-0"
+           x-transition:leave-end="opacity-0 transform -translate-y-2">
+        {% for facet in advanced_facets %}
+          {% snippet 'snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets %}
+        {% endfor %}
+      </div>
+      
+      <!-- Toggle button -->
+      <div class="mt-3 d-flex justify-content-center" x-cloak>
+        <button type="button" 
+                @click="showAdvanced = !showAdvanced"
+                class="btn btn-outline-secondary btn-sm">
+          <i class="fa fa-chevron-down"
+             :class="{ 'fa-chevron-down': !showAdvanced, 'fa-chevron-up': showAdvanced }"></i>
+          <!-- Text spans - one visible by default, Alpine toggles them -->
+          <span x-show="!showAdvanced">{{ _('Show More Filters') }}</span>
+          <span x-show="showAdvanced" style="display: none;">{{ _('Show Fewer Filters') }}</span>
+        </button>
+      </div>
+    {% endif %}
+    </div>
+    <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+  </div>
+
+<style>
+ [x-cloak] { 
+  display: none !important; 
+ }
+</style>
+{% endblock %}

--- a/ckanext/digitizationknowledge/templates/snippets/package_item.html
+++ b/ckanext/digitizationknowledge/templates/snippets/package_item.html
@@ -1,5 +1,11 @@
 {% ckan_extends %}
 
+  {% block heading_title %}
+    <a href="{{ h.url_for('%s.read' % package.type, id=package.name) }}" title="{{ title }}" target="_blank" rel="noopener noreferrer">
+      {{title|truncate(80)}}
+    </a>
+  {% endblock %}
+
 {% block resources %}
   {% if package.in_digitization_academy_course or package.resources and not hide_resources %}
     <div class="dataset-resources-wrapper mt-2">
@@ -8,7 +14,7 @@
            target="_blank" 
            rel="noopener"
            class="btn btn-light btn-sm border me-2 mb-1 shadow-sm"
-           title="{{ _('Digitization Academy Course Material') }}">
+           title="{{ _('Appears in a Digitization Academy course') }}">
           <img src="/logos/digitization_academy.svg"
                alt="{{ _('Digitization Academy Logo') }}"
                width="80" height="28" />


### PR DESCRIPTION
This addresses:

- Dividing facets into basic and advanced.
- Hiding advanced facets at first.
- Reorganize facets order.
- Rewrite the original facets list.
- Digitization resource opens in a new tab when clicked from the search results.

TODO: Explore how to pass the list of facets and order directly from the configuration file wo that source code manipulation is not required.