### PR TITLE
Issue/6 custom order dataset resources fields

### DIFF
--- a/ckanext/digitizationknowledge/templates/package/snippets/additional_info.html
+++ b/ckanext/digitizationknowledge/templates/package/snippets/additional_info.html
@@ -1,0 +1,95 @@
+<section class="additional-info">
+  <h3>{{ _('Additional Info') }}</h3>
+  <table class="table table-bordered table-condensed">
+    <thead>
+      <tr>
+        <th scope="col">{{ _('Field') }}</th>
+        <th scope="col">{{ _('Value') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% block package_additional_info %}
+        {% if pkg_dict.url %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _('Source') }}</th>
+            {% if h.is_url(pkg_dict.url) %}
+              <td class="dataset-details" property="foaf:homepage">
+                <a href="{{ pkg_dict.url }}" rel="foaf:homepage" target="_blank">
+                  {{ pkg_dict.url }}
+                </a>
+              </td>
+            {% else %}
+              <td class="dataset-details" property="foaf:homepage">{{ pkg_dict.url }}</td>
+            {% endif %}
+          </tr>
+        {% endif %}
+
+        {% if pkg_dict.author_email %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Author") }}</th>
+            <td class="dataset-details" property="dc:creator">{{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author) }}</td>
+          </tr>
+        {% elif pkg_dict.author %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Author") }}</th>
+            <td class="dataset-details" property="dc:creator">{{ pkg_dict.author }}</td>
+          </tr>
+        {% endif %}
+
+        {% if pkg_dict.maintainer_email %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
+            <td class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}</td>
+          </tr>
+        {% elif pkg_dict.maintainer %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
+            <td class="dataset-details" property="dc:contributor">{{ pkg_dict.maintainer }}</td>
+          </tr>
+        {% endif %}
+
+        {% if pkg_dict.version %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Version") }}</th>
+            <td class="dataset-details">{{ pkg_dict.version }}</td>
+          </tr>
+        {% endif %}
+
+        {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("State") }}</th>
+            <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
+          </tr>
+        {% endif %}
+        {% if pkg_dict.metadata_modified %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
+            <td class="dataset-details">
+                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
+            </td>
+          </tr>
+        {% endif %}
+        {% if pkg_dict.metadata_created %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Created") }}</th>
+
+            <td class="dataset-details">
+                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_created %}
+            </td>
+          </tr>
+        {% endif %}
+
+      {% block extras scoped %}
+        {% for extra in h.sorted_extras(pkg_dict.extras) %}
+          {% set key, value = extra %}
+          <tr rel="dc:relation" resource="_:extra{{ i }}">
+            <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key|e) }}</th>
+            <td class="dataset-details" property="rdf:value">{{ value }}</td>
+          </tr>
+        {% endfor %}
+      {% endblock %}
+
+      {% endblock %}
+    </tbody>
+  </table>
+</section>

--- a/ckanext/digitizationknowledge/templates/package/snippets/additional_info.html
+++ b/ckanext/digitizationknowledge/templates/package/snippets/additional_info.html
@@ -1,6 +1,7 @@
-<section class="additional-info">
-  <h3>{{ _('Additional Info') }}</h3>
-  <table class="table table-bordered table-condensed">
+<div x-data="{ showMore: false }" x-cloak>
+  <section class="additional-info">
+    <h3>{{ _('Additional Info') }}</h3>
+    <table class="table table-bordered table-condensed">
     <thead>
       <tr>
         <th scope="col">{{ _('Field') }}</th>
@@ -92,4 +93,20 @@
       {% endblock %}
     </tbody>
   </table>
-</section>
+  </section>
+
+  {#- Toggle buttons are placed below the table -#}
+  <div class="text-center" style="padding-top: 10px;">
+    <button x-show="!showMore" @click="showMore = true" class="btn btn-default btn-sm">
+      <i class="fa fa-chevron-down"></i> {{ _('Show more') }}
+    </button>
+    <button x-show="showMore" @click="showMore = false" class="btn btn-default btn-sm" x-cloak>
+      <i class="fa fa-chevron-up"></i> {{ _('Show less') }}
+    </button>
+  </div>
+</div>
+
+{#- Add styles for Alpine's x-cloak to prevent flash of unstyled content -#}
+<style>
+  [x-cloak] { display: none !important; }
+</style>

--- a/ckanext/digitizationknowledge/templates/scheming/package/resource_read.html
+++ b/ckanext/digitizationknowledge/templates/scheming/package/resource_read.html
@@ -1,0 +1,160 @@
+{% extends "package/resource_read.html" %}
+
+{%- set exclude_fields = [
+  'name',
+  'description',
+  'url',
+  ] -%}
+{%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
+
+{#-
+  Define custom field orders. You can specify a default order and then
+  override it for specific dataset types.
+
+  - `custom_order`: Fields to display at the beginning.
+  - `custom_order_end`: Fields to display at the end, inside the collapsible section.
+-#}
+
+{#- Default order (if no type-specific order is set) -#}
+{%- set custom_order = ['date_created', 'date_published', 'date_modified', 'version', 'license'] -%}
+{%- set custom_order_end = ['id', 'package_id', 'state'] -%}
+
+{#- Example of type-specific ordering -#}
+{#- Uncomment and adapt this block for your dataset types
+{% if dataset_type == 'your_dataset_type_name' %}
+    {% set custom_order = ['date_created', 'date_published', 'date_modified', 'version', 'license', 'format'] %}
+    {% set custom_order_end = ['id'] %}
+{% endif %}
+-#}
+
+{#- Helper macro to render a single schema field's table row -#}
+{%- macro render_field(field, res, dataset_type) -%}
+  {#- Capture the rendered output of the display_field snippet into a variable.
+      This is the only robust way to handle all field types (e.g. dates, JSON). -#}
+  {%- set rendered_value -%}
+    {% snippet 'scheming/snippets/display_field.html',
+        field=field,
+        data=res,
+        entity_type='resource',
+        object_type=dataset_type
+    %}{%- endset -%}
+
+  {#- Only render the full table row if the captured output is not just whitespace. -#}
+  {%- if rendered_value and rendered_value|string|trim -%}
+    <tr class="scheming-field">
+      <th scope="row">{{ h.scheming_language_text(field.label) }}</th>
+      <td>{{ rendered_value|safe }}</td>
+    </tr>
+  {%- endif -%}
+{%- endmacro -%}
+
+{% block resource_additional_information_inner %}
+  {#- This block is wrapped in an Alpine.js component to handle the collapsible section -#}
+  <div class="module-content" x-data="{ showMore: false }" x-cloak>
+    {% if res.datastore_active %}
+      {% block resource_data_dictionary %}
+        {{ super() }}
+      {% endblock %}
+    {% endif %}
+
+    {%- block additional_info_heading -%}<h2>{{ _('Additional Information') }}</h2>{%- endblock -%}
+
+    {#- --- Data Preparation --- #}
+    {#- 1. Get all schema fields into a dictionary for easy lookup -#}
+    {%- set fields_by_name = {} -%}
+    {%- for field in schema.resource_fields %}
+      {%- do fields_by_name.update({field.field_name: field}) -%}
+    {%- endfor -%}
+
+    {#- 2. Get all other formatted items into a reliable dictionary, keyed by field name -#}
+    {%- set formatted_items_by_name = {} -%}
+    {%- for label, value in h.format_resource_items(res.items()) -%}
+      {#- Convert the label (e.g. 'Package ID') into a field_name (e.g. 'package_id') -#}
+      {%- set field_name = label.lower().replace(' ', '_') -%}
+      {%- do formatted_items_by_name.update({field_name: (label, value)}) -%}
+    {%- endfor -%}
+
+    <table class="table table-striped table-bordered table-condensed">
+      {%- block additional_info_table_head -%}
+        <thead>
+          <tr>
+            <th scope="col">{{ _('Field') }}</th>
+            <th scope="col">{{ _('Value') }}</th>
+          </tr>
+        </thead>
+      {%- endblock -%}
+      <tbody>
+        {#- --- 1. Render high-priority fields from custom_order --- -#}
+        {#- The render_field macro now correctly handles hiding empty schema fields.
+            A local check is still used for non-schema fields. -#}
+        {%- for field_name in custom_order -%}
+          {%- if field_name in fields_by_name -%}
+            {{ render_field(fields_by_name[field_name], res, dataset_type) }}
+          {%- elif field_name in formatted_items_by_name -%}
+            {%- set label, value = formatted_items_by_name[field_name] -%}
+            {%- if value and value|string|trim -%}
+            <tr>
+              <th scope="row">{{ label | capitalize }}</th>
+              <td>{{ value }}</td>
+            </tr>
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+
+        {#- --- 2. Render 'middle' schema fields by overriding the parent block --- -#}
+        {%- block resource_fields scoped -%}
+          {%- for field in schema.resource_fields -%}
+            {%- if field.field_name not in exclude_fields and field.field_name not in custom_order and field.field_name not in custom_order_end -%}
+              {{ render_field(field, res, dataset_type) }}
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endblock -%}
+
+        {#- --- 3. Override resource_more_items to hold all collapsible content --- -#}
+        {%- block resource_more_items scoped -%}
+          <template x-if="showMore">
+                {#- Render fields from custom_order_end -#}
+                {%- for field_name in custom_order_end -%}
+                  {%- if field_name in fields_by_name -%}
+                    {{ render_field(fields_by_name[field_name], res, dataset_type) }}
+                  {%- elif field_name in formatted_items_by_name -%}
+                    {%- set label, value = formatted_items_by_name[field_name] -%}
+                    {%- if value and value|string|trim -%}
+                    <tr>
+                      <th scope="row">{{ label | capitalize }}</th>
+                      <td>{{ value }}</td>
+                    </tr>
+                    {%- endif -%}
+                  {%- endif -%}
+                {%- endfor -%}
+
+                {#- Render any remaining formatted items that were not explicitly ordered -#}
+                {%- for field_name, (label, value) in formatted_items_by_name.items() -%}
+                    {%- if field_name not in custom_order and field_name not in custom_order_end and value and value|string|trim -%}
+                        <tr>
+                            <th scope="row">{{ label | capitalize }}</th>
+                            <td>{{ value }}</td>
+                        </tr>
+                    {%- endif -%}
+                {%- endfor -%}
+          </template>
+        {%- endblock -%}
+      </tbody>
+    </table>
+
+    {#- Toggle buttons are placed outside the table for a clean UI -#}
+    <div class="text-center" style="padding-top: 10px;">
+      <button x-show="!showMore" @click="showMore = true" class="btn btn-default btn-sm">
+        <i class="fa fa-chevron-down"></i> {{ _('Show more') }}
+      </button>
+      <button x-show="showMore" @click="showMore = false" class="btn btn-default btn-sm" x-cloak>
+        <i class="fa fa-chevron-up"></i> {{ _('Show less') }}
+      </button>
+    </div>
+  </div>
+
+  {#- Add styles for Alpine's x-cloak to prevent flash of unstyled content -#}
+  <style>
+    [x-cloak] { display: none !important; }
+  </style>
+{% endblock %}

--- a/ckanext/digitizationknowledge/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/digitizationknowledge/templates/scheming/package/snippets/additional_info.html
@@ -73,18 +73,20 @@
     {%- endif -%}
   {%- endfor -%}
 
-  {#- 3. Render the fields from custom_order_end -#}
-  {%- for field_name in custom_order_end -%}
-    {%- set field = fields_by_name.get(field_name) -%}
-    {%- if field -%}
-      {{ render_field(field, pkg_dict, schema) }}
-    {%- endif -%}
-  {%- endfor -%}
+  {#- 3. Render the fields from custom_order_end (advanced fields) -#}
+  <template x-if="showMore">
+    {%- for field_name in custom_order_end -%}
+      {%- set field = fields_by_name.get(field_name) -%}
+      {%- if field -%}
+        {{ render_field(field, pkg_dict, schema) }}
+      {%- endif -%}
+    {%- endfor -%}
 
-  {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
-    <tr>
-      <th scope="row" class="dataset-label">{{ _("State") }}</th>
-      <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
-    </tr>
-  {% endif %}
+    {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
+      <tr>
+        <th scope="row" class="dataset-label">{{ _("State") }}</th>
+        <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
+      </tr>
+    {% endif %}
+  </template>
 {% endblock %}

--- a/ckanext/digitizationknowledge/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/digitizationknowledge/templates/scheming/package/snippets/additional_info.html
@@ -8,20 +8,79 @@
     'owner_org',
     ] -%}
 
+{#-
+  Define custom field orders. You can specify a default order and then
+  override it for specific dataset types.
+
+  - `custom_order`: Fields to display at the beginning.
+  - `custom_order_end`: Fields to display at the end.
+
+  Example for a dataset type 'my_dataset_type':
+  {% if pkg_dict.type == 'my_dataset_type' %}
+    {% set custom_order = ['important_field', 'another_field'] %}
+    {% set custom_order_end = ['less_important_field'] %}
+  {% endif %}
+-#}
+
+{#- Default order (if no type-specific order is set) -#}
+{%- set custom_order = ['url', 'task_clusters', 'task', 'preparations', 'tags', 'digitization_academy_course', 'discipline', 'audience', 'in_language', 'category', 'organization', 'groups', 'in_digitization_academy_course', 'type'] -%}
+{%- set custom_order_end = ['id', 'state'] -%}
+
+{#- Example of type-specific ordering -#}
+{#- Uncomment and adapt this block for your dataset types
+{% if pkg_dict.type == 'your_dataset_type_name_1' %}
+    {% set custom_order = ['field_a', 'field_b'] %}
+    {% set custom_order_end = ['field_z'] %}
+{% elif pkg_dict.type == 'your_dataset_type_name_2' %}
+    {% set custom_order = ['field_x', 'field_y'] %}
+{% endif %}
+-#}
+
+{#- A helper macro to render a field's table row -#}
+{%- macro render_field(field, pkg_dict, schema) -%}
+  {#- This macro checks against `exclude_fields` before rendering -#}
+  {%- if field.field_name not in exclude_fields
+      and field.display_snippet is not none and pkg_dict.get(field.field_name,"") -%}
+    <tr>
+      <th scope="row" class="dataset-label">{{
+        h.scheming_language_text(field.label) }}</th>
+      <td class="dataset-details"{%- if field.display_property %} property="{{ field.display_property
+        }}"{% endif %}>{%- snippet 'scheming/snippets/display_field.html',
+        field=field, data=pkg_dict, schema=schema -%}</td>
+    </tr>
+  {%- endif -%}
+{%- endmacro -%}
+
 {% block package_additional_info %}
+  {#- Create a dictionary of fields for efficient lookups -#}
+  {%- set fields_by_name = {} -%}
   {%- for field in schema.dataset_fields -%}
-    {%- if field.field_name not in exclude_fields
-        and field.display_snippet is not none and pkg_dict.get(field.field_name,"") -%}
-      <tr>
-        <th scope="row" class="dataset-label">{{
-          h.scheming_language_text(field.label) }}</th>
-        <td class="dataset-details"{%
-          if field.display_property %} property="{{ field.display_property
-          }}"{% endif %}>{%- snippet 'scheming/snippets/display_field.html',
-          field=field, data=pkg_dict, schema=schema -%}</td>
-      </tr>
+    {%- do fields_by_name.update({field.field_name: field}) -%}
+  {%- endfor -%}
+
+  {#- 1. Render the fields from custom_order -#}
+  {%- for field_name in custom_order -%}
+    {%- set field = fields_by_name.get(field_name) -%}
+    {%- if field -%}
+      {{ render_field(field, pkg_dict, schema) }}
     {%- endif -%}
   {%- endfor -%}
+
+  {#- 2. Render the 'middle' fields -#}
+  {%- for field in schema.dataset_fields -%}
+    {%- if field.field_name not in custom_order and field.field_name not in custom_order_end -%}
+      {{ render_field(field, pkg_dict, schema) }}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {#- 3. Render the fields from custom_order_end -#}
+  {%- for field_name in custom_order_end -%}
+    {%- set field = fields_by_name.get(field_name) -%}
+    {%- if field -%}
+      {{ render_field(field, pkg_dict, schema) }}
+    {%- endif -%}
+  {%- endfor -%}
+
   {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
     <tr>
       <th scope="row" class="dataset-label">{{ _("State") }}</th>


### PR DESCRIPTION
This includes creating custom lists of fields inside the templates to be able to reorder them and adding a functionality for dynamically hiding by default certain fields.

For the datasets, two templates needed to be changed. The additional_info in the scheming extension and the one in the base CKAN.

